### PR TITLE
Remove CuckooFilter

### DIFF
--- a/.github/config/cargo-deny.toml
+++ b/.github/config/cargo-deny.toml
@@ -19,9 +19,6 @@ ignore = [
 multiple-versions = "deny"
 
 skip-tree = [
-    # This dependency needs to be updated or removed (see https://github.com/axiomhq/rust-cuckoofilter/pull/53)
-    { name = "cuckoofilter" },
-
     # all of these are going to be just test dependencies
     { name = "bach" },
     { name = "bolero" },

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -21,8 +21,7 @@ provider-tls-fips = [
     "s2n-quic-rustls?/fips",
 ]
 provider-address-token-default = [
-    "cuckoofilter",
-    "hash_hasher",
+    "fastbloom",
     "s2n-quic-crypto",
     "zerocopy",
     "zeroize",
@@ -65,9 +64,8 @@ unstable-provider-connection-close-formatter = []
 [dependencies]
 bytes = { version = "1", default-features = false }
 cfg-if = "1"
-cuckoofilter = { version = "0.5", optional = true }
+fastbloom = { version = "0.14", optional = true }
 futures = { version = "0.3", default-features = false, features = ["std"] }
-hash_hasher = { version = "2", optional = true }
 humansize = { version = "2", optional = true }
 rand = "0.9"
 rand_chacha = "0.9"


### PR DESCRIPTION
CuckooFilter is one of the only things in aranya pulling in an old version of `rand`. See https://github.com/aranya-project/aranya/issues/438.